### PR TITLE
Fix: Add file modification time to IS_CHANGED for external updates support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -996,7 +996,17 @@ class LocalImageGallery:
 
     @classmethod
     def IS_CHANGED(cls, selected_image="", source_folder="", **kwargs):
-        return f"{source_folder}:{selected_image}"
+        if not selected_image:
+            return ""
+        
+        root_dir = source_folder if source_folder else folder_paths.get_input_directory()
+        full_path = os.path.join(root_dir, selected_image)
+        
+        mtime = 0
+        if os.path.exists(full_path):
+            mtime = os.path.getmtime(full_path)
+
+        return f"{full_path}:{mtime}"
     
     @classmethod
     def VALIDATE_INPUTS(cls, selected_image="", source_folder="", **kwargs):


### PR DESCRIPTION
    Problem:
    Currently, the IS_CHANGED method only returns the file path/name. If I overwrite an image file externally (e.g., saving changes in Photoshop) while keeping the same filename, ComfyUI doesn't detect the change and uses the cached version of the image.

    Solution:
    I updated the IS_CHANGED method to include the file's modification time (mtime) in the return string.

    Changes:

        Added os.path.getmtime check. Now ComfyUI correctly reloads the image if the file content changes, even if the filename remains the same.

        Optimized the path resolution in IS_CHANGED by removing the redundant load_source_folders() call (JSON parsing) to keep the check fast.